### PR TITLE
Refactor boundary handling

### DIFF
--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -26,9 +26,9 @@ import queue
 import re
 import sys
 import threading
+from io import BytesIO
 from pathlib import Path
 from typing import Union
-from io import BytesIO
 
 import geojson
 import mercantile
@@ -47,8 +47,8 @@ from pySmartDL import SmartDL
 from shapely.geometry import shape
 from shapely.ops import unary_union
 
-from osm_fieldwork.to_bytesio import read_geojson_bytesio
 from osm_fieldwork.sqlite import DataFile, MapTile
+from osm_fieldwork.to_bytesio import read_geojson_bytesio
 from osm_fieldwork.xlsforms import xlsforms_path
 from osm_fieldwork.yamlfile import YamlFile
 
@@ -128,7 +128,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary:Union[str, BytesIO],
+        boundary: Union[str, BytesIO],
         base: str,
         source: str,
         xy: bool,
@@ -137,7 +137,6 @@ class BaseMapper(object):
 
         Args:
             boundary Union[str, BytesIO]: A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI.
-                The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
             xy (bool): Whether to swap the X & Y fields in the TMS URL
@@ -275,7 +274,7 @@ class BaseMapper(object):
 
     def makeBbox(
         self,
-        boundary:Union[str, BytesIO],
+        boundary: Union[str, BytesIO],
     ) -> tuple[float, float, float, float]:
         """Make a bounding box from a shapely geometry.
 
@@ -286,32 +285,31 @@ class BaseMapper(object):
         Returns:
             Tuple[float, float, float, float]: The bounding box coordinates
         """
-
         if isinstance(boundary, BytesIO):
-        # Handle GeoJSON data as BytesIO
+            # Handle GeoJSON data as BytesIO
             log.debug(f"Reading geojson data as BytesIO: {boundary}")
             boundary.seek(0)
             with boundary as b:
                 poly = geojson.load(b)
         elif boundary.lower().endswith((".json", ".geojson")):
-        # Handle GeoJSON file
+            # Handle GeoJSON file
             log.debug(f"Reading geojson file: {boundary}")
             with open(boundary, "r") as f:
-                poly = geojson.load(f) 
+                poly = geojson.load(f)
         else:
-        # Handle Bbox string
+            # Handle Bbox string
             log.debug("Parsing Bbox string")
             try:
                 bbox_parts = boundary.split(",") if "," in boundary else boundary.split(" ")
                 bbox = tuple(float(x) for x in bbox_parts)
-                if len(bbox) == 4:     # BBOX valid
+                if len(bbox) == 4:  # BBOX valid
                     return bbox
                 else:
                     raise ValueError(f"BBOX string malformed: {bbox}")
             except Exception as e:
                 log.error(f"Failed to parse BBOX string: {boundary}.Error:{e}")
-                raise ValueError(f"Failed to parse BBOX string: {boundary}") from e    
-        
+                raise ValueError(f"Failed to parse BBOX string: {boundary}") from e
+
         if "features" in poly:
             geometry = shape(poly["features"][0]["geometry"])
         elif "geometry" in poly:
@@ -570,7 +568,7 @@ def main():
             log.error("")
             parser.print_help()
             quit()
-        boundary_parsed = read_geojson_bytesio(args.boundary[0])        #boundary paramter wrapped in BytesIO object
+        boundary_parsed = read_geojson_bytesio(args.boundary[0])  # boundary paramter wrapped in BytesIO object
     elif len(args.boundary) == 4:
         boundary_parsed = ",".join(args.boundary)
     else:

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -28,6 +28,7 @@ import sys
 import threading
 from pathlib import Path
 from typing import Union
+from io import BytesIO
 
 import geojson
 import mercantile
@@ -46,6 +47,7 @@ from pySmartDL import SmartDL
 from shapely.geometry import shape
 from shapely.ops import unary_union
 
+from osm_fieldwork.to_bytesio import read_geojson_bytesio
 from osm_fieldwork.sqlite import DataFile, MapTile
 from osm_fieldwork.xlsforms import xlsforms_path
 from osm_fieldwork.yamlfile import YamlFile
@@ -126,7 +128,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: str,
+        boundary:Union[str, BytesIO],
         base: str,
         source: str,
         xy: bool,
@@ -134,7 +136,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary (str): A BBOX string or GeoJSON file of the AOI.
+            boundary Union[str, BytesIO]: A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI.
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
@@ -273,41 +275,43 @@ class BaseMapper(object):
 
     def makeBbox(
         self,
-        boundary: str,
+        boundary:Union[str, BytesIO],
     ) -> tuple[float, float, float, float]:
         """Make a bounding box from a shapely geometry.
 
         Args:
-            boundary (str): A BBOX string or GeoJSON file of the AOI.
+            boundary Union[str, BytesIO]: A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI.
                 The GeoJSON can contain multiple geometries.
 
         Returns:
-            (list): The bounding box coordinates
+            Tuple[float, float, float, float]: The bounding box coordinates
         """
-        if not boundary.lower().endswith((".json", ".geojson")):
-            # Is BBOX string
+
+        if isinstance(boundary, BytesIO):
+        # Handle GeoJSON data as BytesIO
+            log.debug(f"Reading geojson data as BytesIO: {boundary}")
+            boundary.seek(0)
+            with boundary as b:
+                poly = geojson.load(b)
+        elif boundary.lower().endswith((".json", ".geojson")):
+        # Handle GeoJSON file
+            log.debug(f"Reading geojson file: {boundary}")
+            with open(boundary, "r") as f:
+                poly = geojson.load(f) 
+        else:
+        # Handle Bbox string
+            log.debug("Parsing Bbox string")
             try:
-                if "," in boundary:
-                    bbox_parts = boundary.split(",")
-                else:
-                    bbox_parts = boundary.split(" ")
+                bbox_parts = boundary.split(",") if "," in boundary else boundary.split(" ")
                 bbox = tuple(float(x) for x in bbox_parts)
-                if len(bbox) == 4:
-                    # BBOX valid
+                if len(bbox) == 4:     # BBOX valid
                     return bbox
                 else:
-                    msg = f"BBOX string malformed: {bbox}"
-                    log.error(msg)
-                    raise ValueError(msg) from None
+                    raise ValueError(f"BBOX string malformed: {bbox}")
             except Exception as e:
-                log.error(e)
-                msg = f"Failed to parse BBOX string: {boundary}"
-                log.error(msg)
-                raise ValueError(msg) from None
-
-        log.debug(f"Reading geojson file: {boundary}")
-        with open(boundary, "r") as f:
-            poly = geojson.load(f)
+                log.error(f"Failed to parse BBOX string: {boundary}.Error:{e}")
+                raise ValueError(f"Failed to parse BBOX string: {boundary}") from e    
+        
         if "features" in poly:
             geometry = shape(poly["features"][0]["geometry"])
         elif "geometry" in poly:
@@ -419,7 +423,7 @@ def create_basemap_file(
     """Create a basemap with given parameters.
 
     Args:
-        boundary (str, optional): The boundary for the area you want.
+        boundary (BytesIO, optional): The boundary for the area you want.
         tms (str, optional): Custom TMS URL.
         xy (bool, optional): Swap the X & Y coordinates when using a
             custom TMS if True.
@@ -446,7 +450,7 @@ def create_basemap_file(
 
     # Validation
     if not boundary:
-        err = "You need to specify a boundary! (file or bbox)"
+        err = "You need to specify a boundary! (BytesIO or optional)"
         log.error(err)
         raise ValueError(err)
 
@@ -566,7 +570,7 @@ def main():
             log.error("")
             parser.print_help()
             quit()
-        boundary_parsed = args.boundary[0]
+        boundary_parsed = read_geojson_bytesio(args.boundary[0])        #boundary paramter wrapped in BytesIO object
     elif len(args.boundary) == 4:
         boundary_parsed = ",".join(args.boundary)
     else:

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -128,7 +128,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: Union[str, BytesIO],          # The boundary parameter representing the AOI
+        boundary: Union[str, BytesIO],
         base: str,
         source: str,
         xy: bool,
@@ -136,7 +136,7 @@ class BaseMapper(object):
         """Create an tile basemap for ODK Collect.
 
         Args:
-            boundary Union[str, BytesIO]: A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI.
+            boundary (Union[str, BytesIO]): A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI
                 The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
@@ -275,12 +275,12 @@ class BaseMapper(object):
 
     def makeBbox(
         self,
-        boundary: Union[str, BytesIO],           # The boundary parameter representing the AOI
+        boundary: Union[str, BytesIO],
     ) -> tuple[float, float, float, float]:
         """Make a bounding box from a shapely geometry.
 
         Args:
-            boundary Union[str, BytesIO]: A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI.
+            boundary (Union[str, BytesIO]): A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI
                 The GeoJSON can contain multiple geometries.
 
         Returns:

--- a/osm_fieldwork/basemapper.py
+++ b/osm_fieldwork/basemapper.py
@@ -128,7 +128,7 @@ class BaseMapper(object):
 
     def __init__(
         self,
-        boundary: Union[str, BytesIO],
+        boundary: Union[str, BytesIO],          # The boundary parameter representing the AOI
         base: str,
         source: str,
         xy: bool,
@@ -137,6 +137,7 @@ class BaseMapper(object):
 
         Args:
             boundary Union[str, BytesIO]: A BBOX string, GeoJSON file, GeoJSON data as BytesIO of the AOI.
+                The GeoJSON can contain multiple geometries.
             base (str): The base directory to cache map tile in
             source (str): The upstream data source for map tiles
             xy (bool): Whether to swap the X & Y fields in the TMS URL
@@ -274,7 +275,7 @@ class BaseMapper(object):
 
     def makeBbox(
         self,
-        boundary: Union[str, BytesIO],
+        boundary: Union[str, BytesIO],           # The boundary parameter representing the AOI
     ) -> tuple[float, float, float, float]:
         """Make a bounding box from a shapely geometry.
 

--- a/osm_fieldwork/to_bytesio.py
+++ b/osm_fieldwork/to_bytesio.py
@@ -1,0 +1,10 @@
+"""Conversion of a GeoJSON file to a BytesIO object for streamlined in-memory data processing."""
+
+from io import BytesIO
+
+def read_geojson_bytesio(file_path):
+    with open(file_path, "rb") as geojson_file:
+        boundary = geojson_file.read()  # read as a `bytes` object.
+        boundary_bytesio = BytesIO(boundary)   # add to a BytesIO wrapper
+
+    return boundary_bytesio

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,0 +1,11 @@
+"""Module for generating .mbtiles archieve"""
+
+from osm_fieldwork.basemapper import create_basemap_file
+
+create_basemap_file(
+    verbose=True,
+    boundary="-4.730494,41.650541,-4.725634,41.652874",
+    outfile="outreachy.mbtiles",
+    zooms="12-15",
+    source="esri",
+)

--- a/outreachy.py
+++ b/outreachy.py
@@ -1,9 +1,11 @@
-"""Module for generating .mbtiles archieve"""
+"""For generating .mbtiles archive"""
 
 from osm_fieldwork.basemapper import create_basemap_file
+from tests.test_basemap import boundary
+
 
 create_basemap_file(
-    boundary="-4.730494,41.650541,-4.725634,41.652874",
+    boundary= boundary,
     outfile="outreachy.mbtiles",
     zooms="12-15",
     source="esri",

--- a/outreachy.py
+++ b/outreachy.py
@@ -3,7 +3,6 @@
 from osm_fieldwork.basemapper import create_basemap_file
 
 create_basemap_file(
-    verbose=True,
     boundary="-4.730494,41.650541,-4.725634,41.652874",
     outfile="outreachy.mbtiles",
     zooms="12-15",

--- a/tests/test_basemap.py
+++ b/tests/test_basemap.py
@@ -25,11 +25,12 @@ import shutil
 
 from osm_fieldwork.basemapper import BaseMapper
 from osm_fieldwork.sqlite import DataFile
+from osm_fieldwork.to_bytesio import read_geojson_bytesio
 
 log = logging.getLogger(__name__)
 
 rootdir = os.path.dirname(os.path.abspath(__file__))
-boundary = f"{rootdir}/testdata/Rollinsville.geojson"
+boundary = read_geojson_bytesio(f"{rootdir}/testdata/Rollinsville.geojson")
 outfile = f"{rootdir}/testdata/rollinsville.mbtiles"
 base = "./tiles"
 # boundary = open(infile, "r")


### PR DESCRIPTION
Fixes [#204](https://github.com/hotosm/osm-fieldwork/issues/204)

Supports:
- In memory GeoJSON format for Bbox passing, with additional support for Bbox string format.
- Parsing GeoJSON inside `main()` function that is only used when running basemapper via command line.

All tests passed:
- formatter and linter 
<img src="https://github.com/Gunjan-Goyal/osm-fieldwork/assets/112609524/f2c95d36-ae38-47d3-a10a-c8160ff82426" width="500">

- Testing code via PyTest
<img src="https://github.com/Gunjan-Goyal/osm-fieldwork/assets/112609524/66d2e501-6f59-4794-95b6-453866d08544" width="500">

- Testing code via Python script
<img src="https://github.com/Gunjan-Goyal/osm-fieldwork/assets/112609524/491207cf-549f-47b0-a476-73066fe4122f" width="500">